### PR TITLE
(feat) Add BodyReader and JsonBodyParser. Fixes iron/iron#287

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ authors = ["Patrick Tran <patrick.tran06@gmail.com>",
 iron = "*"
 rustc-serialize = "*"
 plugin = "*"
+persistent = "*"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,6 @@ authors = ["Patrick Tran <patrick.tran06@gmail.com>",
 
 [dependencies]
 iron = "*"
+rustc-serialize = "*"
+plugin = "*"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,3 @@ iron = "*"
 rustc-serialize = "*"
 plugin = "*"
 persistent = "*"
-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 body-parser [![Build Status](https://secure.travis-ci.org/iron/body-parser.png?branch=master)](https://travis-ci.org/iron/body-parser)
 ====
 
-> Body parsing middleware for the [Iron](https://github.com/iron/iron) web framework.
+> Body parsing plugins for the [Iron](https://github.com/iron/iron) web framework.
 
 ## Example
 
@@ -14,13 +14,34 @@ use persistent::Read;
 use iron::status;
 use iron::prelude::*;
 
+#[derive(Debug, Clone, RustcDecodable)]
+struct MyStructure {
+    a: String,
+    b: Option<String>,
+}
+
 fn log_body(req: &mut Request) -> IronResult<Response> {
-    let parsed = req.get::<bodyparser::BodyReader>();
-    match parsed {
-        Ok(Some(body)) => println!("Parsed body:\n{}", body),
+    let body = req.get::<bodyparser::Raw>();
+    match body {
+        Ok(Some(body)) => println!("Read body:\n{}", body),
         Ok(None) => println!("No body"),
         Err(err) => println!("Error: {:?}", err)
     }
+
+    let json_body = req.get::<bodyparser::Json>();
+    match json_body {
+        Ok(Some(json_body)) => println!("Parsed body:\n{}", json_body),
+        Ok(None) => println!("No body"),
+        Err(err) => println!("Error: {:?}", err)
+    }
+
+    let struct_body = req.get::<bodyparser::Struct<MyStructure>>();
+    match struct_body {
+        Ok(Some(struct_body)) => println!("Parsed body:\n{:?}", struct_body),
+        Ok(None) => println!("No body"),
+        Err(err) => println!("Error: {:?}", err)
+    }
+
     Ok(Response::with(status::Ok))
 }
 
@@ -37,9 +58,11 @@ fn main() {
 
 ## Overview
 
-body-parser is a part of Iron's [core bundle](https://github.com/iron/core).
+body-parser is a part of Iron's [core bundle](https://github.com/iron/core). It contains:
 
-- Perform body parsing to string with limiting.
+* **Raw** - performs body parsing to string with limiting.
+* **Json** - parses body into Json.
+* **Struct** - parses body into a struct using Decode.
 
 ## Installation
 

--- a/examples/bodyparser.rs
+++ b/examples/bodyparser.rs
@@ -1,25 +1,28 @@
 extern crate iron;
 extern crate bodyparser;
-extern crate plugin;
+extern crate persistent;
 
-use plugin::Pluggable;
-
+use persistent::Read;
 use iron::status;
+use iron::prelude::*;
 
-fn log_body(req: &mut iron::Request) -> iron::IronResult<iron::Response> {
+fn log_body(req: &mut Request) -> IronResult<Response> {
     let parsed = req.get::<bodyparser::BodyReader>();
     match parsed {
-        Ok(Some(body)) => println!("Parsed body:\n{}", body),
+        Ok(Some(body)) => println!("Readed body:\n{}", body),
         Ok(None) => println!("No body"),
         Err(err) => println!("Error: {:?}", err)
     }
-    Ok(iron::Response::with(status::Ok))
+    Ok(Response::with(status::Ok))
 }
+
+const MAX_BODY_LENGTH: usize = 1024 * 1024 * 10;
 
 // `curl -i "localhost:3000/" -H "application/json" -d '{"name":"jason","age":"2"}'`
 // and check out the printed json in your terminal.
 fn main() {
-    let chain = iron::Chain::new(log_body);
-    iron::Iron::new(chain).listen("localhost:3000").unwrap();
+    let mut chain = Chain::new(log_body);
+    chain.link_before(Read::<bodyparser::MaxBodyLength>::one(MAX_BODY_LENGTH));
+    Iron::new(chain).listen("localhost:3000").unwrap();
 }
 

--- a/examples/bodyparser.rs
+++ b/examples/bodyparser.rs
@@ -1,18 +1,40 @@
 extern crate iron;
 extern crate bodyparser;
 extern crate persistent;
+extern crate "rustc-serialize" as rustc_serialize;
 
 use persistent::Read;
 use iron::status;
 use iron::prelude::*;
 
+#[derive(Debug, Clone, RustcDecodable)]
+struct MyStructure {
+    a: String,
+    b: Option<String>,
+}
+
 fn log_body(req: &mut Request) -> IronResult<Response> {
-    let parsed = req.get::<bodyparser::BodyReader>();
-    match parsed {
-        Ok(Some(body)) => println!("Readed body:\n{}", body),
+    let body = req.get::<bodyparser::Raw>();
+    match body {
+        Ok(Some(body)) => println!("Read body:\n{}", body),
         Ok(None) => println!("No body"),
         Err(err) => println!("Error: {:?}", err)
     }
+
+    let json_body = req.get::<bodyparser::Json>();
+    match json_body {
+        Ok(Some(json_body)) => println!("Parsed body:\n{:?}", json_body),
+        Ok(None) => println!("No body"),
+        Err(err) => println!("Error: {:?}", err)
+    }
+
+    let struct_body = req.get::<bodyparser::Struct<MyStructure>>();
+    match struct_body {
+        Ok(Some(struct_body)) => println!("Parsed body:\n{:?}", struct_body),
+        Ok(None) => println!("No body"),
+        Err(err) => println!("Error: {:?}", err)
+    }
+
     Ok(Response::with(status::Ok))
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,28 @@
+use std::error::Error as StdError;
+use std::fmt;
+use std::old_io;
+use std::str;
+
+#[derive(Debug, Clone)]
+pub enum BodyErrorCause {
+    Utf8Error(str::Utf8Error),
+    IoError(old_io::IoError)
+}
+
+#[derive(Debug, Clone)]
+pub struct BodyError {
+    pub detail: String,
+    pub cause: BodyErrorCause
+}
+
+impl StdError for BodyError {
+    fn description(&self) -> &str {
+        &self.detail[]
+    }
+}
+
+impl fmt::Display for BodyError {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        self.description().fmt(formatter)
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,11 +2,14 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::old_io;
 use std::str;
+use rustc_serialize::json;
 
 #[derive(Debug, Clone)]
 pub enum BodyErrorCause {
     Utf8Error(str::Utf8Error),
-    IoError(old_io::IoError)
+    IoError(old_io::IoError),
+    ParserError(json::ParserError),
+    DecoderError(json::DecoderError)
 }
 
 #[derive(Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![crate_name = "bodyparser"]
-#![feature(core)]
-#![feature(io)]
+#![feature(core, io)]
 
 //! Body Parser Plugin for Iron
 //!
@@ -11,6 +10,8 @@ extern crate "rustc-serialize" as rustc_serialize;
 extern crate plugin;
 extern crate persistent;
 
+use rustc_serialize::{json, Decodable};
+
 use iron::mime;
 use iron::prelude::*;
 use iron::headers;
@@ -18,7 +19,7 @@ use iron::typemap::{Key};
 use std::old_io::ByRefReader;
 use persistent::Read;
 
-pub use self::errors::{BodyError};
+pub use self::errors::{BodyError, BodyErrorCause};
 pub use self::limit_reader::{LimitReader};
 
 mod errors;
@@ -48,17 +49,17 @@ impl Key for MaxBodyLength {
     type Value = usize;
 }
 
-/// BodyReader is a plugin to read a request body into UTF-8 String.
+/// Raw is a plugin to read a request body into UTF-8 String.
 /// Doesn't read `multipart/form-data`.
-pub struct BodyReader;
+pub struct Raw;
 
-impl Key for BodyReader {
+impl Key for Raw {
     type Value = Option<String>;
 }
 
 const DEFAULT_BODY_LIMIT: usize = 1024 * 1024 * 100;
 
-impl<'a> plugin::Plugin<Request<'a>> for BodyReader {
+impl<'a> plugin::Plugin<Request<'a>> for Raw {
     type Error = BodyError;
 
     fn eval(req: &mut Request) -> Result<Option<String>, BodyError> {
@@ -77,5 +78,61 @@ impl<'a> plugin::Plugin<Request<'a>> for BodyReader {
         } else {
             Ok(None)
         }
+    }
+}
+
+/// Json is a plugin to parse a request body into JSON.
+/// Uses Raw plugin to parse the body with limit.
+#[derive(Clone)]
+pub struct Json;
+impl Key for Json {
+    type Value = Option<json::Json>;
+}
+
+impl<'a> plugin::Plugin<Request<'a>> for Json {
+    type Error = BodyError;
+
+    fn eval(req: &mut Request) -> Result<Option<json::Json>, BodyError> {
+        req.get::<Raw>()
+            .and_then(|maybe_body| {
+                reverse_option(maybe_body.map(|body| body.parse()))
+                    .map_err(|err| {
+                        BodyError {
+                            detail: "Can't parse body to JSON".to_string(),
+                            cause: BodyErrorCause::ParserError(err)
+                        }
+                    })
+            })
+    }
+}
+
+/// Struct is a plugin to parse a request body into a struct.
+/// Uses Raw plugin to parse the body with limit.
+#[derive(Clone)]
+pub struct Struct<T: Decodable>;
+impl<T: 'static + Decodable> Key for Struct<T> {
+    type Value = Option<T>;
+}
+
+impl<'a, T: 'static + Decodable> plugin::Plugin<Request<'a>> for Struct<T> {
+    type Error = BodyError;
+
+    fn eval(req: &mut Request) -> Result<Option<T>, BodyError> {
+        req.get::<Json>()
+            .and_then(|maybe_body| {
+                reverse_option(maybe_body.map(|body| Decodable::decode(&mut json::Decoder::new(body))))
+                    .map_err(|err| BodyError {
+                        detail: "Can't parse body to the struct".to_string(),
+                        cause: BodyErrorCause::DecoderError(err)
+                    })
+            })
+    }
+}
+
+fn reverse_option<T,E>(value: Option<Result<T, E>>) -> Result<Option<T>, E> {
+    match value {
+        Some(Ok(val)) => Ok(Some(val)),
+        Some(Err(err)) => Err(err),
+        None => Ok(None),
     }
 }

--- a/src/limit_reader.rs
+++ b/src/limit_reader.rs
@@ -1,0 +1,43 @@
+use std::old_io;
+use std::cmp;
+
+/// [Original impl](https://github.com/rust-lang/rust/blob/17bc7d8d5be3be9674d702ccad2fa88c487d23b0/src/libstd/old_io/util.rs#L20)
+///
+/// The LimitReader from the `std` just stops to read when reaches a limit, but we don't want
+/// to return partially readed body to the client code because it is useless. This modified LimitReader
+/// returns `IoError` with `IoErrorKind::InvalidInput` when it reaches the limit.
+#[derive(Debug)]
+pub struct LimitReader<R> {
+    limit: usize,
+    inner: R
+}
+
+impl<R: Reader> LimitReader<R> {
+    pub fn new(r: R, limit: usize) -> LimitReader<R> {
+        LimitReader { limit: limit, inner: r }
+    }
+
+    pub fn into_inner(self) -> R { self.inner }
+    pub fn limit(&self) -> usize { self.limit }
+}
+
+impl<R: Reader> Reader for LimitReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> old_io::IoResult<usize> {
+        if self.limit == 0 {
+            // Changed code is here
+            return Err(old_io::IoError {
+                kind: old_io::IoErrorKind::InvalidInput,
+                desc: "Body is too big",
+                detail: None
+            })
+        }
+
+        let len = cmp::min(self.limit, buf.len());
+        let res = self.inner.read(&mut buf[..len]);
+        match res {
+            Ok(len) => self.limit -= len,
+            _ => {}
+        }
+        res
+    }
+}


### PR DESCRIPTION
Hello @reem. I have had some time to think about iron/iron#287 and I found out that we can't use the current plugin infrastructure because it doesn't allow to report errors. I think that it is bad for end-user. So I decided to rewrite the whole `body_parser` to be a library that just helps to read body into String with proper `limit`.

If we really want this to be a plugin we need to make plugins return `Result`. Note that I had to copy LimitReader because the default one doesn't report errors. 

I'd like to write some tests for this PR, but at first I need to hear your opinion.