### PR TITLE
(feat) Rustup and use Arc to resolve issues with `Error` and `Clone`

### DIFF
--- a/examples/bodyparser.rs
+++ b/examples/bodyparser.rs
@@ -1,7 +1,7 @@
 extern crate iron;
 extern crate bodyparser;
 extern crate persistent;
-extern crate "rustc-serialize" as rustc_serialize;
+extern crate rustc_serialize;
 
 use persistent::Read;
 use iron::status;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,10 +1,11 @@
 use std::error::Error as StdError;
 use std::fmt;
 use std::io;
+use std::sync;
 use std::str;
 use rustc_serialize::json;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum BodyErrorCause {
     Utf8Error(str::Utf8Error),
     IoError(io::Error),
@@ -15,7 +16,7 @@ pub enum BodyErrorCause {
 #[derive(Debug, Clone)]
 pub struct BodyError {
     pub detail: String,
-    pub cause: BodyErrorCause
+    pub cause: sync::Arc<BodyErrorCause>
 }
 
 impl StdError for BodyError {

--- a/src/limit_reader.rs
+++ b/src/limit_reader.rs
@@ -26,7 +26,7 @@ impl<R: io::Read> io::Read for LimitReader<R> {
         if self.limit == 0 {
             // Changed code is here
             return Err(io::Error::new(
-                io::ErrorKind::InvalidInput, "Body is too big", None))
+                io::ErrorKind::InvalidInput, "Body is too big"))
         }
 
         let len = cmp::min(self.limit, buf.len());


### PR DESCRIPTION
Hello @reem, please take a look at this PR. I use Arc to make Errors to be clonable again.

This PR compiles only on nightly because we need marker::Reflect

