### PR TITLE
(chore) Upgrade to serde 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ keywords = ["iron", "web", "http", "parsing", "parser"]
 iron = { version = "0.2", default-features = false }
 plugin = "0.2"
 persistent = "0"
-serde = "0.6.11"
-serde_json = "0.6.0"
+serde = "0.7"
+serde_json = "0.7"

--- a/examples/bodyparser.rs
+++ b/examples/bodyparser.rs
@@ -27,7 +27,7 @@ impl Deserialize for MyStructure {
     {
         static FIELDS: &'static [&'static str] = &["a", "b"];
 
-        deserializer.visit_struct("MyStructure", FIELDS, MyStructureVisitor)
+        deserializer.deserialize_struct("MyStructure", FIELDS, MyStructureVisitor)
     }
 }
 
@@ -93,12 +93,12 @@ impl Deserialize for MyStructureField {
                 match value {
                     "a" => Ok(MyStructureField::A),
                     "b" => Ok(MyStructureField::B),
-                    _ => Err(serde::de::Error::syntax("expected a or b")),
+                    _ => Err(serde::de::Error::custom("expected a or b")),
                 }
             }
         }
 
-        deserializer.visit(MyStructureFieldVisitor)
+        deserializer.deserialize(MyStructureFieldVisitor)
     }
 }
 


### PR DESCRIPTION
This is a breaking change because the interface of our re-exported `serde_json::Value` has changed.