### PR TITLE
(chore) Update to iron 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ authors = ["Patrick Tran <patrick.tran06@gmail.com>",
 keywords = ["iron", "web", "http", "parsing", "parser"]
 
 [dependencies]
-iron = { version = "0.2", default-features = false }
+iron = "0.3"
 plugin = "0.2"
-persistent = "0"
+persistent = { git = "https://github.com/calebmer/persistent" }
 serde = "0.7"
 serde_json = "0.7"


### PR DESCRIPTION
I wanted to upgrade `iron-test` to work with `iron` 0.3. To do this the dependencies also had to be updated. But this isn't the end, we most go deeper!

## Dependencies
- [x] Merge iron/persistent#52
- [x] Publish updated `persistent` version