### PR TITLE
Bump Serde to 0.8.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ keywords = ["iron", "web", "http", "parsing", "parser"]
 iron = "0.4"
 plugin = "0.2"
 persistent = "0.2"
-serde = "0.7"
-serde_json = "0.7"
+serde = "0.8"
+serde_json = "0.8"


### PR DESCRIPTION
None of the Serde APIs used by bodyparser changed, so this was a trivial upgrade.