### PR TITLE
Bump Serde to 0.9 and use serde_derive.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,8 @@ keywords = ["iron", "web", "http", "parsing", "parser"]
 iron = "0.5"
 plugin = "0.2"
 persistent = "0.3"
-serde = "0.8"
-serde_json = "0.8"
+serde = "0.9"
+serde_json = "0.9"
+
+[dev-dependencies]
+serde_derive = "0.9"

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ body-parser [![Build Status](https://secure.travis-ci.org/iron/body-parser.png?b
 extern crate iron;
 extern crate bodyparser;
 extern crate persistent;
+#[macro_use]
+extern crate serde_derive;
 
 use persistent::Read;
 use iron::status;
 use iron::prelude::*;
 
-// Automatically deriving from `Deserialize` requires serde_macros or serde_codegen + syntex.
-// See https://github.com/serde-rs/serde for details.
 #[derive(Debug, Clone, Deserialize)]
 struct MyStructure {
     a: String,


### PR DESCRIPTION
This patch updates bodyparser to use the recently released [Serde 0.9](https://github.com/serde-rs/serde/releases/tag/v0.9.0). None of the API changes affect this crate, so this is just to allow downstream crates to use the latest Serde without getting type mismatches because of bodyparser's older Serde.

I also removed the manually implemented deserialization, instead using the serde_derive crate, which uses macros 1.1. The example program will fail to compile on stable right now, but it will work in a few days when Rust 1.15 is released, which will stabilize macros 1.1. bodyparser only depends on serde_derive as a dev dependency, so it's safe to publish these changes without breaking bodyparser's use on stable Rust, even before Rust 1.15 is released.