### PR TITLE
Update serde to 1.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ keywords = ["iron", "web", "http", "parsing", "parser"]
 iron = "0.5"
 plugin = "0.2"
 persistent = "0.3"
-serde = "0.9"
-serde_json = "0.9"
+serde = "1.0"
+serde_json = "1.0"
 
 [dev-dependencies]
-serde_derive = "0.9"
+serde_derive = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,15 +115,15 @@ impl<'a, 'b> plugin::Plugin<Request<'a, 'b>> for Json {
 
 /// Struct is a plugin to parse a request body into a struct.
 /// Uses Raw plugin to parse the body with limit.
-pub struct Struct<T: Deserialize> {
+pub struct Struct<T> where T: for<'a> Deserialize<'a> {
     marker: marker::PhantomData<T>
 }
-impl<T> Key for Struct<T> where T: Deserialize + Any {
+impl<T> Key for Struct<T> where T: for<'a> Deserialize<'a> + Any {
     type Value = Option<T>;
 }
 
 impl<'a, 'b, T> plugin::Plugin<Request<'a, 'b>> for Struct<T>
-where T: Deserialize + Any {
+where T: for<'c> Deserialize<'c> + Any {
     type Error = BodyError;
 
     fn eval(req: &mut Request) -> Result<Option<T>, BodyError> {


### PR DESCRIPTION
Now that serde is 1.0, this should be the last time we'll need to update it! 🎉 

This will require a new release of body-parser once merged to unblock downstream projects from upgrading to serde 1.0.