### PR TITLE
Add crates.io version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-body-parser [![Build Status](https://secure.travis-ci.org/iron/body-parser.png?branch=master)](https://travis-ci.org/iron/body-parser)
+body-parser
 ====
+
+[![Build Status](https://secure.travis-ci.org/iron/body-parser.png?branch=master)](https://travis-ci.org/iron/body-parser)
+[![Crates.io](https://img.shields.io/crates/v/bodyparser.svg)](https://crates.io/crates/bodyparser)
 
 > Body parsing plugins for the [Iron](https://github.com/iron/iron) web framework.
 


### PR DESCRIPTION
This is nice when you want to know what the latest version is, to be able to put it into the `Cargo.toml` :)