### PR TITLE
bump iron to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["iron", "web", "http", "parsing", "parser"]
 [dependencies]
 iron = "0.6"
 plugin = "0.2"
-persistent = "0.3"
+persistent = "0.4"
 serde = "1.0"
 serde_json = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Patrick Tran <patrick.tran06@gmail.com>",
 keywords = ["iron", "web", "http", "parsing", "parser"]
 
 [dependencies]
-iron = "0.5"
+iron = "0.6"
 plugin = "0.2"
 persistent = "0.3"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "bodyparser"
-version = "0.7.0"
+version = "0.8.0"
 license = "MIT"
 description = "Body parsing middleware for Iron."
 repository = "https://github.com/iron/body-parser"
@@ -11,7 +11,7 @@ authors = ["Patrick Tran <patrick.tran06@gmail.com>",
 keywords = ["iron", "web", "http", "parsing", "parser"]
 
 [dependencies]
-iron = "0.6"
+iron = ">= 0.5, < 0.7"
 plugin = "0.2"
 persistent = "0.4"
 serde = "1.0"


### PR DESCRIPTION
I'm getting some weird ICE with Iron 0.6 and it's not helping having `body-parser` and `persistent` pull in `iron 0.5` as well as my `iron 0.6`, so.. let's just upgrade everything to 0.6?

I've confirmed that this will build *after* the `persistent` change is merged, but will probably ICE or give a weird error before then:
 * https://github.com/iron/persistent/pull/64
 * https://github.com/rust-lang/rust/issues/45801